### PR TITLE
Fixing even more warnings...

### DIFF
--- a/cmake/CheckDGtalOptionalDependencies.cmake
+++ b/cmake/CheckDGtalOptionalDependencies.cmake
@@ -45,6 +45,17 @@ endif()
 MESSAGE(STATUS " ")
 #---------------------------------
 
+#----------------------------------
+# Removing -frounding-math compile flag for clang
+#----------------------------------
+IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    MESSAGE( STATUS "Removing -frounding-math flag when compiling with Clang" )
+    STRING( REPLACE "-frounding-math" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} )
+    MESSAGE( STATUS " " )
+ENDIF()
+#---------------------------------
+
+
 IF(WITH_C11)
 SET (LIST_OPTION ${LIST_OPTION} [c++11]\ )
 message(STATUS "      WITH_C11           true    (C++ compiler C11 features)")

--- a/examples/geometry/curves/freemanChainDisplay.cpp
+++ b/examples/geometry/curves/freemanChainDisplay.cpp
@@ -61,7 +61,6 @@ int main()
   
   typedef SpaceND<2> Space2;
   typedef HyperRectDomain<Space2> TDomain;
-  typedef TDomain::Vector Vector;
 
   //Default image selector = STLVector
   typedef ImageSelector<TDomain, unsigned char>::Type Image;

--- a/src/DGtal/arithmetic/StandardDSLQ0.ih
+++ b/src/DGtal/arithmetic/StandardDSLQ0.ih
@@ -365,7 +365,7 @@ reversedSmartDSS( Point U1, Point U2,
 #ifdef TRACE_DSL
       std::cerr << "  - greatest:" << subpattern.rE() << " at " << startPos << endl;
 #endif
-      ASSERT( n );
+      ASSERT( n ); boost::ignore_unused_variable_warning(n);
       Point NU( U1 + startPos );
       Integer nmu = subpattern.slope().p() * NU[ 0 ]
         - subpattern.slope().q() * NU[ 1 ];
@@ -424,7 +424,7 @@ DSSWithinTwoPatterns( Point U1, Point U2,
               bool n = patLU.getGreatestIncludedSubpattern
                 ( subpattern, nb, startPos, 
                   ( A - U1 ).norm1(), ( Um - U1 ).norm1(), false );
-              ASSERT( n );
+              ASSERT( n ); boost::ignore_unused_variable_warning(n);
               readyLU = true;
             }
           patLU = subpattern;
@@ -440,7 +440,7 @@ DSSWithinTwoPatterns( Point U1, Point U2,
               bool n = patRU.getGreatestIncludedSubpattern
                 ( subpattern, nb, startPos, 
                    0, ( B - Um ).norm1(), false );
-              ASSERT( n );
+              ASSERT( n ); boost::ignore_unused_variable_warning(n);
               readyRU = true;
             }
           patRU = subpattern;
@@ -457,7 +457,7 @@ DSSWithinTwoPatterns( Point U1, Point U2,
             {
               bool n = patL.getGreatestIncludedSubpattern
                 ( subpattern, nb, startPos, posA, posB, true );
-              ASSERT( n );
+              ASSERT( n ); boost::ignore_unused_variable_warning(n);
               patL = subpattern;
               readyL = true;
             }

--- a/src/DGtal/base/Common.h
+++ b/src/DGtal/base/Common.h
@@ -95,7 +95,7 @@
 #define UNUSED(identifier) /* identifier */
 #else
 #define UNUSED_PARAM  param
-#define UNUSED(identifier)  identifier
+#define UNUSED(identifier) /* identifier */
 #endif
 
 

--- a/src/DGtal/dec/DiscreteExteriorCalculus.ih
+++ b/src/DGtal/dec/DiscreteExteriorCalculus.ih
@@ -50,6 +50,7 @@ DGtal::DiscreteExteriorCalculus<dimEmbedded, dimAmbient, TLinearAlgebraBackend, 
     // FIXME should be open or closed? => closed = true
     const bool kspace_init_ok = const_cast<KSpace&>(myKSpace).init(_domain->lowerBound(), _domain->upperBound(), true);
     ASSERT(kspace_init_ok);
+    boost::ignore_unused_variable_warning(kspace_init_ok);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/DGtal/dec/DiscreteExteriorCalculusFactory.ih
+++ b/src/DGtal/dec/DiscreteExteriorCalculusFactory.ih
@@ -163,6 +163,7 @@ DGtal::DiscreteExteriorCalculusFactory<TLinearAlgebraBackend, TInteger>::createF
         const SCell cell_signed = *ci;
         const Dimension cell_dim = calculus.myKSpace.sDim(cell_signed);
         ASSERT_MSG( cell_dim == dimEmbedded, "wrong n-cell dimension" );
+        boost::ignore_unused_variable_warning(cell_dim);
 
         calculus.insertSCell(cell_signed);
 

--- a/src/DGtal/dec/DiscreteExteriorCalculusFactory.ih
+++ b/src/DGtal/dec/DiscreteExteriorCalculusFactory.ih
@@ -144,9 +144,9 @@ DGtal::DiscreteExteriorCalculusFactory<TLinearAlgebraBackend, TInteger>::createF
     typedef typename Calculus::Cell Cell;
     typedef typename Calculus::SCell SCell;
     typedef typename Calculus::Scalar Scalar;
-    typedef typename Calculus::Point Point;
-    typedef typename Calculus::Property Property;
-    typedef typename Calculus::Properties Properties;
+    //typedef typename Calculus::Point Point;
+    //typedef typename Calculus::Property Property;
+    //typedef typename Calculus::Properties Properties;
     typedef typename Calculus::KSpace KSpace;
     typedef typename KSpace::Cells Cells;
 

--- a/src/DGtal/geometry/curves/FP.ih
+++ b/src/DGtal/geometry/curves/FP.ih
@@ -160,7 +160,7 @@ DGtal::FP<TIterator,TInteger,connectivity>::
 algorithm(const TIterator& itb, 
 	  const TIterator& ite, CirculatorType ) throw( InputException ) 
 {
-  ASSERT(isNotEmpty(itb,ite)); 
+  ASSERT(isNotEmpty(itb,ite)); boost::ignore_unused_variable_warning(ite);
 
   /////////////////////////// closed
   //first maximal DSS

--- a/src/DGtal/geometry/curves/FrechetShortcut.h
+++ b/src/DGtal/geometry/curves/FrechetShortcut.h
@@ -584,9 +584,9 @@ namespace DGtal
 	 @param p and @param q two points
 	 @return an int
       */
-    static int computeQuadrant(Point p, Point q)
+    static int computeOctant(Point p, Point q)
     {
-      int d;
+      int d = 0;
       Coordinate x = q[0]-p[0];
       Coordinate y = q[1]-p[1];
       

--- a/src/DGtal/geometry/curves/FrechetShortcut.ih
+++ b/src/DGtal/geometry/curves/FrechetShortcut.ih
@@ -830,7 +830,7 @@ bool DGtal::FrechetShortcut<TIterator,TInteger>::isBackpathOk()
   Point firstP = Point(*myBegin);
   Point P = Point(*(myEnd+1));
   
-  int q = Tools::computeQuadrant(firstP,P);
+  int q = Tools::computeOctant(firstP,P);
   
   
   // to handle non simple curves (a point is visited twice)

--- a/src/DGtal/geometry/curves/StandardDSS6Computer.ih
+++ b/src/DGtal/geometry/curves/StandardDSS6Computer.ih
@@ -235,6 +235,9 @@ DGtal::StandardDSS6Computer<TIterator,TInteger,connectivity>::extendFront()
     bool XZflag = myXZalgo.extendFront();
     bool YZflag = myYZalgo.extendFront();
     ASSERT( (XYflag)&&(XZflag)&&(YZflag) );
+    boost::ignore_unused_variable_warning(XYflag);
+    boost::ignore_unused_variable_warning(XZflag);
+    boost::ignore_unused_variable_warning(YZflag);
 
     myEnd++;
     return true;

--- a/src/DGtal/geometry/surfaces/COBANaivePlaneComputer.ih
+++ b/src/DGtal/geometry/surfaces/COBANaivePlaneComputer.ih
@@ -680,7 +680,7 @@ void
 DGtal::COBANaivePlaneComputer<TSpace, TInternalInteger>::selfDisplay ( std::ostream & out ) const
 {
   double min, max;
-  double N[ 3 ];
+  double N[] = {0., 0., 0.};
   out << "[COBANaivePlaneComputer"
       << " axis=" << myAxis << " w=" << myWidth[ 0 ] << "/" << myWidth[ 1 ]
       << " size=" << size() << " complexity=" << complexity() << " N=" << myState.N << ": ";

--- a/src/DGtal/geometry/surfaces/estimation/VCMGeometricFunctors.h
+++ b/src/DGtal/geometry/surfaces/estimation/VCMGeometricFunctors.h
@@ -232,7 +232,8 @@ namespace DGtal {
         ASSERT( myVCMOnDigitalSurface != 0 );
         RealVector lambda;
         bool ok = myVCMOnDigitalSurface->getChiVCMEigenvalues( lambda, s );
-        ASSERT( ok );
+        ASSERT( ok ); boost::ignore_unused_variable_warning( ok );
+        
         // The last eigenvalue l2 is approximately the mixed "area" 2pi R^3 r^2 / 3
         // The greatest principal curvature is related to the second eigenvalue l1.
         // k1^2 = 4*l1 / (l2*r^2)
@@ -300,7 +301,8 @@ namespace DGtal {
         ASSERT( myVCMOnDigitalSurface != 0 );
         RealVector lambda;
         bool ok = myVCMOnDigitalSurface->getChiVCMEigenvalues( lambda, s );
-        ASSERT( ok );
+        ASSERT( ok ); boost::ignore_unused_variable_warning( ok );
+        
         // The last eigenvalue l2 is approximately the mixed "area" 2pi R^3 r^2 / 3
         // The smallest principal curvature is related to the first eigenvalue l0.
         // k2^2 = 4*l0 / (l2*r^2)
@@ -367,7 +369,7 @@ namespace DGtal {
         ASSERT( myVCMOnDigitalSurface != 0 );
         RealVector lambda;
         bool ok = myVCMOnDigitalSurface->getChiVCMEigenvalues( lambda, s );
-        ASSERT( ok );
+        ASSERT( ok ); boost::ignore_unused_variable_warning( ok );
 
         // The last eigenvalue l2 is approximately the mixed "area" 2pi R^3 r^2 / 3
         // The greatest principal curvature is related to the second eigenvalue l1.

--- a/src/DGtal/geometry/surfaces/estimation/VCMGeometricFunctors.h
+++ b/src/DGtal/geometry/surfaces/estimation/VCMGeometricFunctors.h
@@ -163,7 +163,8 @@ namespace DGtal {
         ASSERT( myVCMOnDigitalSurface != 0 );
         RealVector lambda;
         bool ok = myVCMOnDigitalSurface->getChiVCMEigenvalues( lambda, s );
-        ASSERT( ok );
+        ASSERT( ok ); boost::ignore_unused_variable_warning( ok );
+
         // The last eigenvalue l1 is approximately the mixed "area" 8pi R^3 r / 3
         // The curvature is related to the first eigenvalue l0.
         // k1^2 = 3*l0 / (l1*r^2)

--- a/src/DGtal/geometry/volumes/distance/ChamferNorm2D.ih
+++ b/src/DGtal/geometry/volumes/distance/ChamferNorm2D.ih
@@ -122,6 +122,7 @@ DGtal::experimental::ChamferNorm2D<TSpace>::getLowerRayIntersection(const Vector
 {
   ASSERT(Lmin[aDimension] < Lmax[aDimension]);
   ASSERT(Lmin[(aDimension+1) %2] == Lmax[(aDimension+1)%2]);
+  boost::ignore_unused_variable_warning(Lmax);
   
   double slope, y;
   if (aDimension == 1)
@@ -175,6 +176,7 @@ DGtal::experimental::ChamferNorm2D<TSpace>::getUpperRayIntersection(const Vector
 {
   ASSERT(Lmin[aDimension] < Lmax[aDimension]);
   ASSERT(Lmin[(aDimension+1) %2] == Lmax[(aDimension+1)%2]);
+  boost::ignore_unused_variable_warning(Lmax);
 
   double slope, y;
   if (aDimension == 1)

--- a/src/DGtal/geometry/volumes/distance/FMMPointFunctors.ih
+++ b/src/DGtal/geometry/volumes/distance/FMMPointFunctors.ih
@@ -980,7 +980,7 @@ DGtal::SpeedExtrapolator<TDistanceImage,TSet,TSpeedFunctor>::operator()
       //distance value
       DistanceValue d = 0; 
       bool flag = findAndGetValue( *myDistImgPtr, *mySetPtr, aPoint, d );
-      ASSERT( flag ); 
+      ASSERT( flag ); boost::ignore_unused_variable_warning( flag );
 
       //neighbors
       *it1 = (c+1); 

--- a/src/DGtal/geometry/volumes/distance/FMMPointFunctors.ih
+++ b/src/DGtal/geometry/volumes/distance/FMMPointFunctors.ih
@@ -133,7 +133,7 @@ DGtal::L2FirstOrderLocalDistance<TImage, TSet>::operator()
       *it2 = (c-1);
 
       //neighboring values
-      Value d, d1, d2 = 0; 
+      Value d = 0, d1 = 0, d2 = 0; 
       bool flag1 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor1, d1 );
       bool flag2 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor2, d2 );
       if ( flag1 || flag2 ) 
@@ -318,7 +318,7 @@ DGtal::L2SecondOrderLocalDistance<TImage, TSet>::operator()
       double coeff = 1.0; 
       ++(*it1); 
       --(*it2);
-      Value d, d1, d2 = 0; 
+      Value d = 0, d1 = 0, d2 = 0; 
       bool flag1 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor1, d1 );
       bool flag2 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor2, d2 );
       if ( flag1 || flag2 ) 
@@ -326,7 +326,7 @@ DGtal::L2SecondOrderLocalDistance<TImage, TSet>::operator()
 	  /// second-order
 	  ++(*it1); 
 	  --(*it2);
-	  Value d12, d22 = 0; 
+	  Value d12 = 0, d22 = 0; 
 	  bool flag12 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor1, d12 );
 	  bool flag22 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor2, d22 );
 
@@ -530,7 +530,7 @@ DGtal::LInfLocalDistance<TImage, TSet>::operator()
       *it2 = (c-1);
 
       //neighboring values
-      Value d, d1, d2 = 0; 
+      Value d = 0, d1 = 0, d2 = 0; 
       bool flag1 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor1, d1 );
       bool flag2 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor2, d2 );
       if ( flag1 || flag2 ) 
@@ -668,7 +668,7 @@ DGtal::L1LocalDistance<TImage, TSet>::operator()
       *it2 = (c-1);
 
       //neighboring values
-      Value d1, d2 = 0; 
+      Value d1 = 0, d2 = 0; 
       bool flag1 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor1, d1 );
       bool flag2 = findAndGetValue( *myImgPtr, *mySetPtr, neighbor2, d2 );
       if (flag1) v.push_back( d1 );
@@ -988,7 +988,7 @@ DGtal::SpeedExtrapolator<TDistanceImage,TSet,TSpeedFunctor>::operator()
       //neighboring speed value
       Value s = 0; 
       //neighboring distance values
-      DistanceValue d0, d1, d2 = 0; 
+      DistanceValue d0 = 0, d1 = 0, d2 = 0; 
       bool flag1 = findAndGetValue( *myDistImgPtr, *mySetPtr, neighbor1, d1 );
       bool flag2 = findAndGetValue( *myDistImgPtr, *mySetPtr, neighbor2, d2 );
       if ( flag1 || flag2 ) 

--- a/src/DGtal/io/Display2DFactory.ih
+++ b/src/DGtal/io/Display2DFactory.ih
@@ -179,7 +179,6 @@ DGtal::Display2DFactory::drawWithColorMap(DGtal::Board2D& board, const DGtal::KF
 {
     typedef typename TCalculus::Scalar Scalar;
     typedef typename TCalculus::SCell SCell;
-    typedef typename TCalculus::KSpace KSpace;
 
     for (typename TCalculus::Index index=0; index<kform.length(); index++)
     {

--- a/src/DGtal/io/Display3D.ih
+++ b/src/DGtal/io/Display3D.ih
@@ -532,6 +532,7 @@ DGtal::Display3D< Space ,KSpace >::addPrism(const RealPoint &baseQuadCenter,
 
 
   ASSERT( xSurfel || ySurfel || zSurfel );
+  boost::ignore_unused_variable_warning( xSurfel );
 
   if(zSurfel)
     {
@@ -695,9 +696,9 @@ DGtal::Display3D< Space ,KSpace >::addQuadFromSurfelCenter(const RealPoint &base
 {
   updateBoundingBox(baseQuadCenter);
   ASSERT( xSurfel || ySurfel || zSurfel );
-  double x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4;
+  boost::ignore_unused_variable_warning( xSurfel );
 
-  ASSERT( xSurfel || ySurfel || zSurfel );
+  double x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4;
 
   if(zSurfel)
     {
@@ -738,9 +739,9 @@ DGtal::Display3D< Space ,KSpace >::addQuadFromSurfelCenterWithNormal(const RealP
 {
   updateBoundingBox(baseQuadCenter);
   ASSERT( xSurfel || ySurfel || zSurfel );
+  boost::ignore_unused_variable_warning( xSurfel );
+  
   double x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4;
-
-  ASSERT( xSurfel || ySurfel || zSurfel );
 
   if(zSurfel)
     {

--- a/src/DGtal/io/Display3DFactory.ih
+++ b/src/DGtal/io/Display3DFactory.ih
@@ -105,7 +105,6 @@ DGtal::Display3DFactory<Space, KSpace>::drawWithColorMap(Display3D<Space, KSpace
     ASSERT( kform.myCalculus );
 
     typedef typename Calculus::Scalar Scalar;
-    typedef typename Calculus::KSpace KSpace;
     typedef typename Calculus::SCell SCell;
     typedef typename Calculus::Index Index;
 

--- a/src/DGtal/io/Display3DFactory.ih
+++ b/src/DGtal/io/Display3DFactory.ih
@@ -1577,7 +1577,8 @@ void DGtal::Display3DFactory<Space,KSpace>::draw( Display & display, const DGtal
   bool zodd = ( aTransformedPrism.mySurfel.myCoordinates[ 2 ] & 1 );
 
   unsigned int spaceDim= (xodd ? 1:0) + (yodd ? 1:0) + (zodd ? 1:0);
-  ASSERT(spaceDim==2);
+  ASSERT(spaceDim ==2 );
+  boost::ignore_unused_variable_warning(spaceDim);
 
   //display.addSurfelPrism(rps[0], rps[1], rps[2],! xodd, !yodd, !zodd, factorVolSurfel, aTransformedSurfelPrism.mySizeFactor, true, aTransformedSurfelPrism.mySurfel.myPositive );
   display.addPrism(DGtal::Z3i::RealPoint(rps[0]+(xodd? 0:0.5 ), rps[1]+(yodd? 0:0.5 ), rps[2]+(zodd? 0:0.5 )),! xodd, !yodd, !zodd, factorVolSurfel,1.0, true, aTransformedPrism.mySurfel.myPositive );

--- a/src/DGtal/topology/DigitalSurface.ih
+++ b/src/DGtal/topology/DigitalSurface.ih
@@ -296,7 +296,7 @@ head( const Arc & a ) const
   Vertex s;
   myTracker->move( a.base );
   uint8_t code = myTracker->adjacent( s, a.k, a.epsilon );
-  ASSERT( code != 0 );
+  ASSERT( code != 0 ); boost::ignore_unused_variable_warning(code);
   return s;
 }
 //-----------------------------------------------------------------------------

--- a/src/DGtal/topology/helpers/Surfaces.ih
+++ b/src/DGtal/topology/helpers/Surfaces.ih
@@ -917,17 +917,17 @@ sWriteBoundary( OutputIterator & out_it,
                 const PointPredicate & pp,
                 const Point & aLowerBound, const Point & aUpperBound  )
 {
-  Dimension k;
   // bool in_here, in_further;
-  bool in_here, in_before;
+  bool in_here = false, in_before = false;
   
   typedef typename KSpace::Space Space;
   typedef HyperRectDomain<Space> Domain;
   std::vector< Dimension > axes( aKSpace.dimension ); 
-  for ( k = 0; k < aKSpace.dimension; ++k )
+  for ( Dimension k = 0; k < aKSpace.dimension; ++k )
     axes[ k ] = k;
+  
   // We look for surfels in every direction.
-  for ( k = 0; k < aKSpace.dimension; ++k )
+  for ( Dimension k = 0; k < aKSpace.dimension; ++k )
     {
       // When looking for surfels, the visiting must follow the k-th
       // axis first so as to reuse the predicate "pp( p )".

--- a/tests/dec/common.h
+++ b/tests/dec/common.h
@@ -438,7 +438,7 @@ test_hodge_sign()
         const DGtal::Z2i::DigitalSet set(domain);
         const Calculus calculus = CalculusFactory::createFromDigitalSet(set);
         typedef DGtal::Z2i::Point Point;
-        typedef typename Calculus::KSpace KSpace;
+
         // primal point, dual cell
         FATAL_ERROR( calculus.hodgeSign( calculus.myKSpace.uCell(Point(0,0)), DGtal::PRIMAL ) == 1 );
         FATAL_ERROR( calculus.hodgeSign( calculus.myKSpace.uCell(Point(0,0)), DGtal::DUAL ) == 1 );
@@ -459,7 +459,7 @@ test_hodge_sign()
         const DGtal::Z3i::DigitalSet set(domain);
         const Calculus calculus = CalculusFactory::createFromDigitalSet(set);
         typedef DGtal::Z3i::Point Point;
-        typedef typename Calculus::KSpace KSpace;
+        
         // primal point, dual cell
         FATAL_ERROR( calculus.hodgeSign( calculus.myKSpace.uCell(Point(0,0,0)), DGtal::PRIMAL ) == 1 );
         FATAL_ERROR( calculus.hodgeSign( calculus.myKSpace.uCell(Point(0,0,0)), DGtal::DUAL ) == 1 );

--- a/tests/dec/testEmbedding.cpp
+++ b/tests/dec/testEmbedding.cpp
@@ -23,7 +23,7 @@ equal(const OperatorAA& aa, const OperatorBB& bb)
     return MatrixXd(aa.myContainer) == MatrixXd(bb.myContainer);
 }
 
-int main(int argc, char* argv[])
+int main(int UNUSED(argc), char** UNUSED(argv))
 {
 #if !defined(NOVIEWER)
     typedef Viewer3D<Z3i::Space, Z3i::KSpace> Viewer;

--- a/tests/geometry/curves/testArithmeticalDSL.cpp
+++ b/tests/geometry/curves/testArithmeticalDSL.cpp
@@ -336,8 +336,6 @@ bool rangeTest(const DSL& dsl)
 template <typename DSL>
 bool sameOctantTest(const DSL& dsl1, const DSL& dsl2)
 {
-  typedef typename DSL::Point Point; 
-
   trace.beginBlock ( "Test same octant" );
   trace.info() << dsl1  << " " << dsl2 << std::endl; 
   

--- a/tests/io/readers/testMagickReader.cpp
+++ b/tests/io/readers/testMagickReader.cpp
@@ -66,7 +66,6 @@ bool testMagickReader()
 
   typedef SpaceND<2> Space2;
   typedef HyperRectDomain<Space2> TDomain;
-  typedef TDomain::Vector Vector;
   
   //Default image selector = STLVector
   typedef ImageSelector<TDomain, unsigned char>::Type Image;


### PR DESCRIPTION
#### With g++ 4.9.2 (Debian 3.16.7)

Using following options:
BUILD_EXAMPLES
BUILD_SHARED_LIBS
BUILD_TESTINGS
WITH_C11
WITH_CGAL
WITH_EIGEN
WITH_GMP
WITH_HDF5
WITH_MAGICK
WITH_OPENMP
WITH_QGLVIEWER
and compile flags `-Wall -Wextra`, the remaining warnings are about the following points:
- Ignoring warning 'assuming signed overflow does not occur when assuming that (X + c) >= X is always true' in src/DGtal/geometry/volumes/distance/ExactPredicateLpPowerSeparableMetric.ih:294 (-Wstrict-overflow activated by -Wall). It is triggered because of compiler optimization. Should we add a compiler exception for this function ?
- Ignoring "array subscript is above array bounds" in DGtal/io/boards/Board3D.ih:181 (-Warray-bounds activated by -Wall). In debug mode, there is an assert to verify that the index is in the bounds. In release, because of this assert is ignored, the compiler complained about bounds checking. We should mayby throw an exception ?
- Ignoring "‘aValue’ may be used uninitialized in this function" in src/DGtal/images/TiledImage.h:710 (-Wmayby-uninitialized activated by -Wall). There is no trivial solution to initialize aValue. Alternatively, we should get the read result on line 728 and throw an exception if failed.
#### With clang++ 3.5.0 (Debian 3.16.7)

Using following options:
BUILD_EXAMPLES
BUILD_SHARED_LIBS
BUILD_TESTINGS
WITH_C11
WITH_CGAL
WITH_EIGEN
WITH_GMP
WITH_HDF5
WITH_MAGICK
~~WITH_OPENMP~~
WITH_QGLVIEWER
and compile flags `-Wall -Wextra`, the remaining warnings are about the following point:
- Ignoring "'binder1st' is deprecated [-Wdeprecated-declarations]" in src/DGtal/geometry/surfaces/estimation/LocalEstimatorFromSurfelFunctorAdapter.h:145 because this function is deprecated since C++11.
#### General

I have modified the UNUSED macro in Common.h since it hides unused parameter only in Debug mode. The UNUSED_PARAM macro is strange because it lefts the documentation for unused parameter (see eg http://dgtal.org/doc/nightly/classDGtal_1_1SeparableMetricAdapter.html#a932f2272f78c976b483ffa4dc08c089f )
