### PR TITLE
Cmake glob for doxygen markdown and cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,10 +85,9 @@ include(DevelopmentOptions)
 include(OSDependentSettings)
 
 # -----------------------------------------------------------------------------
-# Check Mandatory Dependencies
+# Check dependencies
 # -----------------------------------------------------------------------------
 include(CheckDGtalDependencies)
-
 include(CheckDGtalOptionalDependencies)
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,8 @@
     [#1580](https://github.com/DGtal-team/DGtal/pull/1580))
   - Continuous integration does not use Travis anymore but Github
     Actions. (David Coeurjolly, [#1591](https://github.com/DGtal-team/DGtal/pull/1591))
+  - New cmake targets to collect cmake, doxygen and markdown files (David Coeurjolly,
+    [#1609](https://github.com/DGtal-team/DGtal/pull/1609))
 
 ## Changes
 

--- a/cmake/GeneratorSpecific.cmake
+++ b/cmake/GeneratorSpecific.cmake
@@ -8,6 +8,13 @@
 #/implementation, ...)
 #
 #------------------------------------------------------------------------------
+FILE(GLOB_RECURSE DGTAL_MYHEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.dox)
+add_custom_target(doxygen SOURCES ${DGTAL_MYHEADERS})
+FILE(GLOB_RECURSE DGTAL_MYHEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.md)
+add_custom_target(markdown SOURCES ${DGTAL_MYHEADERS})
+FILE(GLOB_RECURSE DGTAL_MYHEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.cmake)
+add_custom_target(cmake SOURCES ${DGTAL_MYHEADERS})
+
 FILE(GLOB_RECURSE DGTAL_MYHEADERS ${CMAKE_CURRENT_SOURCE_DIR}/src/DGtal//base/*h)
 add_custom_target(_base SOURCES ${DGTAL_MYHEADERS})
 set(DGTAL_MYHEADERS "")


### PR DESCRIPTION
# PR Description

Collects markdown, doxygen and cmake files into dedicated cmake targets.

# Checklist

- [x] Unit-test of your feature with [Catch](http://dgtal.org/doc/stable/moduleCatch.html).
- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Documentation module page added or updated.
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtal/blob/master/ChangeLog.md) added.
- [x] No warning raised in Debug ```cmake``` mode (otherwise, C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor)